### PR TITLE
Add basic support for "with", so code inside the with block can be tr…

### DIFF
--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -419,7 +419,24 @@ class RustTranspiler(CLikeTranspiler):
         return "raise!({0}); //unsupported".format(self.visit(node.exc))
 
     def visit_With(self, node):
-        return "with!({0}); //unsupported".format(self.visit(node.body))
+        buf = []
+
+        with_statement = "with!("
+        for i in node.items:
+            if i.optional_vars:
+                with_statement += "{0} as {1}, ".format(self.visit(i.context_expr),
+                                                        self.visit(i.optional_vars))
+            else:
+                with_statement += "{0}, ".format(self.visit(i.context_expr))
+        with_statement = with_statement[:-2] + ") { //unsupported"
+        buf.append(with_statement)
+
+        for n in node.body:
+            buf.append(self.visit(n))
+
+        buf.append('}')
+
+        return "\n".join(buf)
 
     def visit_Await(self, node):
         return "await!({0})".format(self.visit(node.value))


### PR DESCRIPTION
…anspiled.

Add basic support for "with", so code inside the "with" block can be transpiled
while the "with" statement itself is still unimplemented and no traceback is
generated when encountering a "with" block (AttributeError: 'list' object has
no attribute '_fields').

Examples:
```python
# ==> test_with.py <==
with open('a.txt', 'r') as fh:
    for line in fh:
        print(line)

# ==> test_with_two.py <==
with open('a.txt', 'r') as fh_r, open('b.txt', 'w') as fh_w:
    for line in fh_r:
        print(line, file=fh_w)

# ==> test_with_two_no_as.py <==
with open('a.txt', 'r') as fh_r, open('b.txt', 'w'):
    for line in fh_r:
        print(line)

```

Generate output:
```bash
for py in test_with.py test_with_two.py test_with_two_no_as.py ; do
    printf '// %s\n' "${py%.py}.rs";
    ./pyrs.py ${py};
    printf '\n\n\n';
done
```

Output:
```rust
// test_with.rs
with!(open("a.txt", "r") as fh) { //unsupported
for line in fh {
println!("{:?} ",line);
}
}


// test_with_two.rs
with!(open("a.txt", "r") as fh_r, open("b.txt", "w") as fh_w) { //unsupported
for line in fh_r {
println!("{:?} ",line);
}
}


// test_with_two_no_as.rs
with!(open("a.txt", "r") as fh_r, open("b.txt", "w")) { //unsupported
for line in fh_r {
println!("{:?} ",line);
}
}
```