### PR TITLE
handle raise with no exception listed

### DIFF
--- a/pyrs/transpiler.py
+++ b/pyrs/transpiler.py
@@ -450,7 +450,11 @@ class RustTranspiler(CLikeTranspiler):
         return "{0}.drop();".format(self.visit(target))
 
     def visit_Raise(self, node):
-        return "raise!({0}); //unsupported".format(self.visit(node.exc))
+        if node.exc is not None:
+            return "raise!({0}); //unsupported".format(self.visit(node.exc))
+        # This handles the case where `raise` is used without
+        # specifying the exception.
+        return "raise!(); //unsupported"
 
     def visit_With(self, node):
         buf = []


### PR DESCRIPTION
Hey, thanks for your work on this library.

I was seeing errors converting files which used `raise` without specifying the exception, like:

```
try:
    pass
except:
    raise
```

This PR resolves that issue. 