### PR TITLE
Translate 'a is b' to 'a == b'. Eg. 'a is None' -> 'a == None'

### DIFF
--- a/pyrs/clike.py
+++ b/pyrs/clike.py
@@ -3,6 +3,7 @@ import ast
 
 symbols = {
     ast.Eq: "==",
+    ast.Is: '==',
     ast.NotEq: '!=',
     ast.Pass: '/*pass*/',
     ast.Mult: '*',


### PR DESCRIPTION
Allows translating the following python code
```
if my_var is None:
    do_stuff()
```
to this rust code
```
if my_var == None {
    do_stuff();
}
```